### PR TITLE
Don't overwrite user-provided CPPFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
-CC = g++
-CPPFLAGS = -std=c++11
+CXX ?= g++
+CPPFLAGS += -std=c++11
 TARGET = progress_bar
 OBJ = main.o progress_bar.o
 
@@ -7,15 +7,15 @@ all : progress_bar
 
 progress_bar : $(OBJ)
 	@echo "<***Linking***> $@"
-	@$(CC) $(CPPFLAGS) $(OBJ) -o $(TARGET)
+	@$(CXX) $(CPPFLAGS) $(OBJ) -o $(TARGET)
 
 main.o : main.cpp
 	@echo "<**Compiling**> $@"
-	@$(CC) $(CPPFLAGS) -c $^
+	@$(CXX) $(CPPFLAGS) -c $^
 
 progress_bar.o : progress_bar.cpp
 	@echo "<**Compiling**> $@"
-	@$(CC) $(CPPFLAGS) -c $^
+	@$(CXX) $(CPPFLAGS) -c $^
 
 clean :
 	@rm -rf progress_bar $(OBJ)


### PR DESCRIPTION
Also, use CXX instead of CC when g++ is meant